### PR TITLE
[Feat] 내가 저장한 전시회 저장 및 취소 서버 연결하기 (#36)

### DIFF
--- a/Hyangyu/Hyangyu/Resources/Storyboards/DetailViewPage.storyboard
+++ b/Hyangyu/Hyangyu/Resources/Storyboards/DetailViewPage.storyboard
@@ -62,7 +62,11 @@
                                                     <constraint firstAttribute="height" constant="20" id="C4u-K7-aBF"/>
                                                     <constraint firstAttribute="width" constant="20" id="JAr-Qe-KX0"/>
                                                 </constraints>
-                                                <state key="normal" image="heart"/>
+                                                <color key="tintColor" red="0.0" green="0.33333333329999998" blue="0.31372549020000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                <state key="normal" image="heart" catalog="system"/>
+                                                <connections>
+                                                    <action selector="likeButtonDidTap:" destination="Cbm-bF-b24" eventType="touchUpInside" id="Beg-tY-uXQ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ef0-8f-2NI">
                                                 <rect key="frame" x="374" y="509" width="20" height="20"/>
@@ -469,22 +473,12 @@
                             <constraint firstItem="0Kg-Ll-bQl" firstAttribute="height" secondItem="xJl-7E-W3I" secondAttribute="height" priority="250" id="zWm-4D-vwb"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="Title" id="Qx5-Ip-I3M">
-                        <barButtonItem key="leftBarButtonItem" image="back 1" style="plain" id="1rI-3d-pvv">
-                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="uNj-mU-FCW">
-                                <rect key="frame" x="20" y="7" width="32" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" image="back 1"/>
-                            </button>
-                            <connections>
-                                <action selector="backButtonClicked:" destination="Cbm-bF-b24" id="tg3-nS-Ump"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Title" id="Qx5-Ip-I3M"/>
                     <size key="freeformSize" width="414" height="1500"/>
                     <connections>
                         <outlet property="endDateLabel" destination="Faw-DM-4fV" id="13Q-lZ-qmn"/>
                         <outlet property="holidayLabel" destination="5Ei-0Z-dHM" id="RxE-hA-NcH"/>
+                        <outlet property="likeButton" destination="qth-N3-kfU" id="h7k-xL-HN8"/>
                         <outlet property="locationLabel" destination="l2I-Y0-lmV" id="Kir-JJ-CNx"/>
                         <outlet property="mainPosterImageView" destination="PbR-2Z-oAW" id="s1m-ol-GqZ"/>
                         <outlet property="priceLabel" destination="goz-Ss-DjJ" id="BWu-gt-PVW"/>
@@ -522,9 +516,8 @@
         </scene>
     </scenes>
     <resources>
-        <image name="back 1" width="32" height="30"/>
         <image name="e1" width="430" height="602"/>
-        <image name="heart" width="100" height="100"/>
+        <image name="heart" catalog="system" width="128" height="109"/>
         <image name="report" width="15" height="4"/>
         <image name="share" width="20" height="20"/>
         <systemColor name="labelColor">

--- a/Hyangyu/Hyangyu/Sources/APIModels/MyPage.swift
+++ b/Hyangyu/Hyangyu/Sources/APIModels/MyPage.swift
@@ -16,7 +16,6 @@ struct ModifyCheckData: Codable {
 struct MyPageResponse: Codable {
     let image: String?
     let username: String
-    var displays: [Event]
 }
 
 // MARK: - SavedResponse
@@ -35,7 +34,7 @@ struct Event: Codable {
     let photo1: String
     let photo2, photo3: String?
     let price: Int
-    let saved: Bool
+    var saved: Bool
 
     enum CodingKeys: String, CodingKey {
         case eventID = "eventId"

--- a/Hyangyu/Hyangyu/Sources/APIServices/SavedAPI/SavedService.swift
+++ b/Hyangyu/Hyangyu/Sources/APIServices/SavedAPI/SavedService.swift
@@ -13,6 +13,10 @@ enum SavedService {
     
     case getMyDisplay(page: Int)
     
+    case saveMyDisplay(displayId: Int)
+    
+    case deleteMySavedDisplay(displayId: Int)
+    
 }
 
 extension SavedService: TargetType, AccessTokenAuthorizable {
@@ -27,8 +31,10 @@ extension SavedService: TargetType, AccessTokenAuthorizable {
         switch self {
         case .getMyDisplay(let page):
             return Const.URL.displayURL + "/\(page)"
-            
-            
+        case .saveMyDisplay(let displayID):
+            return Const.URL.displayURL + "/\(displayID)"
+        case .deleteMySavedDisplay(let displayID):
+            return Const.URL.displayURL + "/\(displayID)"
         }
     }
     
@@ -36,6 +42,10 @@ extension SavedService: TargetType, AccessTokenAuthorizable {
         switch self {
         case .getMyDisplay:
             return .get
+        case .saveMyDisplay:
+            return .post
+        case .deleteMySavedDisplay:
+            return .delete
             
         }
     }
@@ -47,16 +57,15 @@ extension SavedService: TargetType, AccessTokenAuthorizable {
     
     var task: Task {
         switch self {
-        case .getMyDisplay:
+        case .getMyDisplay, .saveMyDisplay, .deleteMySavedDisplay:
             return .requestPlain
-            
         }
     }
     
     var headers: [String: String]? {
         
         switch self {
-        case .getMyDisplay:
+        case .getMyDisplay, .saveMyDisplay, .deleteMySavedDisplay:
             return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(UserDefaults.standard.string(forKey: "jwtToken") ?? "")"
@@ -64,3 +73,4 @@ extension SavedService: TargetType, AccessTokenAuthorizable {
         }
     }
 }
+

--- a/Hyangyu/Hyangyu/Sources/ViewControllers/DetailPageViewController.swift
+++ b/Hyangyu/Hyangyu/Sources/ViewControllers/DetailPageViewController.swift
@@ -93,7 +93,6 @@ class DetailPageViewController: UIViewController {
         } else {
             likeButton.setImage(UIImage(systemName: "heart"), for: .normal)
         }
-        likeButton.tintColor = .primary
     }
     
     // MARK: - @IBAction

--- a/Hyangyu/Hyangyu/Sources/ViewControllers/DetailPageViewController.swift
+++ b/Hyangyu/Hyangyu/Sources/ViewControllers/DetailPageViewController.swift
@@ -24,6 +24,7 @@ class DetailPageViewController: UIViewController {
     @IBOutlet weak var weekendCloseLabel: UILabel!
     @IBOutlet weak var priceLabel: UILabel!
     @IBOutlet weak var siteLabel: UILabel!
+    @IBOutlet weak var likeButton: UIButton!
     
     // MARK: - Properties
     
@@ -38,16 +39,13 @@ class DetailPageViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
+        self.navigationController?.initWithBackButton()
         configureUI()
     }
     
     // MARK: - Functions
     
     func configure(with event: Event) {
-        print(event)
         self.event.append(event)
     }
     
@@ -67,10 +65,60 @@ class DetailPageViewController: UIViewController {
         priceLabel?.text = "\(event[0].price)"
         siteLabel?.text = event[0].site
         
+        setButton()
+        
     }
-    //
+    // 토스트 메세지
+    private func showToast(message: String) {
+        // 토스트 위치
+        let toastLabel = UILabel(frame: CGRect(x: 30,
+                                               y: self.view.frame.size.height - 95,
+                                               width: self.view.frame.size.width - 60,
+                                               height: 40))
+        toastLabel.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        toastLabel.textColor = UIColor.white
+        toastLabel.text = message
+        toastLabel.textAlignment = .center
+        toastLabel.layer.cornerRadius = 12
+        toastLabel.clipsToBounds = true
+        self.view.addSubview(toastLabel)
+        UIView.animate(withDuration: 1.0, delay: 0.5,
+                       options: .curveEaseIn, animations: { toastLabel.alpha = 0.0 },
+                       completion: {_ in toastLabel.removeFromSuperview() })
+    }
+    
+    func setButton() {
+        if event[0].saved {
+            likeButton.setImage(UIImage(systemName: "heart.fill"), for: .normal)
+        } else {
+            likeButton.setImage(UIImage(systemName: "heart"), for: .normal)
+        }
+        likeButton.tintColor = .primary
+    }
     
     // MARK: - @IBAction
+    @IBAction func likeButtonDidTap(_ sender: UIButton) {
+        if event[0].saved {
+            likeButton.setImage(UIImage(systemName: "heart.fill"), for: .normal)
+            deleteMySavedDisplay(displayId: event[0].eventID) {[weak self] response in
+                NotificationCenter.default.post(
+                    name: NSNotification.Name("RefreshMyExhibitionCollectionView"),
+                    object: nil,
+                    userInfo: nil
+                )
+            }
+        } else {
+            likeButton.setImage(UIImage(systemName: "heart"), for: .normal)
+            saveMyDisplay(displayID: event[0].eventID) {[weak self] response in
+                NotificationCenter.default.post(
+                    name: NSNotification.Name("RefreshMyExhibitionCollectionView"),
+                    object: nil,
+                    userInfo: nil
+                )
+            }
+        }
+        
+    }
     
     @IBAction func writeReviewButtonClicked(_ sender: Any) {
         guard let writeReviewVC = writeReviewStoryboard.instantiateViewController(identifier: "WriteReviewViewController") as? WriteReviewViewController else {return}
@@ -91,6 +139,61 @@ class DetailPageViewController: UIViewController {
     
     @IBAction func backButtonClicked(_ sender: Any) {
         self.navigationController?.popViewController(animated: true)
+    }
+    
+}
+
+extension DetailPageViewController {
+    
+    @objc func saveMyDisplay(displayID: Int, completion: @escaping(String) -> Void) {
+        SavedAPI.shared.saveMyDisplay(displayID: displayID) { [self] response in
+            switch response {
+            case .success(let data):
+                if let data = data as? String {
+                    self.showToast(message: data)
+                    self.likeButton.setImage(UIImage(systemName: "heart.fill"), for: .normal)
+                    event[0].saved = true
+                    completion(data)
+                }
+            case .requestErr(let message):
+                print("requestErr", message)
+                if let message = message as? String {
+                    self.showToast(message: message)
+                }
+            case .pathErr:
+                print("pathErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("networkFail")
+            }
+        }
+    }
+    
+    @objc func deleteMySavedDisplay(displayId: Int, completion: @escaping(String) -> Void) {
+        SavedAPI.shared.deleteMySavedDisplay(displayID: displayId) { [self] response in
+            switch response {
+            case .success(let data):
+                if let data = data as? String {
+                    self.showToast(message: data)
+                    self.likeButton.setImage(UIImage(systemName: "heart"), for: .normal)
+                    event[0].saved = false
+                    completion(data)
+                }
+            case .requestErr(let message):
+                print("requestErr", message)
+                if let message = message as? String {
+                    print("얘도?")
+                    self.showToast(message: message)
+                }
+            case .pathErr:
+                print("pathErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("networkFail")
+            }
+        }
     }
     
 }

--- a/Hyangyu/Hyangyu/Sources/ViewControllers/MyPage/MyExhibitionViewController.swift
+++ b/Hyangyu/Hyangyu/Sources/ViewControllers/MyPage/MyExhibitionViewController.swift
@@ -81,7 +81,7 @@ class MyExhibitionViewController: UIViewController, CustomChildViewController  {
     }
     
     private func addObserver() {
-        NotificationCenter.default.addObserver(self, selector: #selector(getMyDisplay), name: NSNotification.Name("RefreshMyCollectionView"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didDismissDetailNotification), name: NSNotification.Name("RefreshMyExhibitionCollectionView"), object: nil)
     }
     
     private func updateData(display: SavedResponse) {
@@ -136,6 +136,17 @@ class MyExhibitionViewController: UIViewController, CustomChildViewController  {
     func customChildScrollView() -> UIScrollView {
         return collectionView
     }
+    
+    @objc func didDismissDetailNotification(_ notification: Notification) {
+        self.allData =  SavedResponse(displays: [Event]())
+        self.currentData = SavedResponse(displays: [Event]())
+        self.currentPage = 0
+        self.isPaging = false // 현재 페이징 중인지 체크
+        self.isLast = false // 마지막 페이지인지 체크
+        self.cachedPages = []
+        getMyDisplay(page: currentPage)
+        
+    }
 }
 
 // MARK: - UICollectionViewDataSource, UICollectionViewDelegate
@@ -170,6 +181,7 @@ extension MyExhibitionViewController: UICollectionViewDataSource, UICollectionVi
         
     }
     
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return allData.displays.count
     }
@@ -190,13 +202,14 @@ extension MyExhibitionViewController: UICollectionViewDataSource, UICollectionVi
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let result = allData.displays[indexPath.row]
-        let detailPageStoryboard = UIStoryboard(name: "DetailViewPage", bundle: nil)
+        let detailPageStoryboard = UIStoryboard.init(name: "DetailViewPage", bundle: nil)
         guard let detailPageVC = detailPageStoryboard.instantiateViewController(withIdentifier: "DetailPageViewController") as? DetailPageViewController else {
             return
         }
         detailPageVC.configure(with: result)
         detailPageVC.title = result.title
         detailPageVC.navigationItem.largeTitleDisplayMode = .never
+        self.navigationController?.isNavigationBarHidden = false
         detailPageVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(detailPageVC, animated: true)
     }
@@ -214,7 +227,6 @@ extension MyExhibitionViewController  {
                         self.cachedPages.append(page)
                     }
                 case .requestErr(let message):
-                    print("얘도 문제야?")
                     print("requestErr", message)
                 case .pathErr:
                     print("pathErr")

--- a/Hyangyu/Hyangyu/Sources/ViewControllers/MyPage/MyPageViewController.swift
+++ b/Hyangyu/Hyangyu/Sources/ViewControllers/MyPage/MyPageViewController.swift
@@ -23,7 +23,7 @@ final class MyPageViewController: CustomPageViewController  {
     // MARK: - Property
     
     private let tabTitles:[String] = ["전시회", "박람회", "페스티벌"]
-    private var userName: String = "이물사딱아요"
+    private var userName: String = ""
     private var userImage: UIImage =  Image.userDefaultImage
     
     private let profileEditVC = ProfileEditViewController(nibName: "ProfileEditViewController", bundle: nil)
@@ -70,7 +70,6 @@ final class MyPageViewController: CustomPageViewController  {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        print("이게 실행되요")
         getUserData()
     }
     
@@ -91,11 +90,6 @@ final class MyPageViewController: CustomPageViewController  {
         )
         navigationItem.rightBarButtonItem?.tintColor = .textBlack
     }
-    
-//    private func configure() {
-//        print(userName)
-//        profileEditVC.configure(with: ProfileEditViewControllerViewModel(profileImage: self.userImage, userName: self.userName))
-//    }
     
     
     @objc func didTapSettings() {
@@ -186,10 +180,10 @@ extension MyPageViewController: HeaderViewDelegate {
 
 // MARK: - ProfileEditViewControllerDelegate
 extension MyPageViewController: ProfileEditViewControllerDelegate {
-    func setUpdate(data: MyPageResponse, profileImage: UIImage?) {
-        headerView.configure(with: HeaderViewViewModel(profileImage: profileImage, userName: data.username))
+    func setUpdate(data: MyPageResponse) {
+        headerView.configure(with: HeaderViewViewModel(profileImage: userImage, userName: data.username))
         self.userName = data.username
-        self.userImage = profileImage ?? Image.userDefaultImage
+        profileEditVC.configure(with: ProfileEditViewControllerViewModel(profileImage: userImage, userName: self.userName))
     }
 }
 
@@ -202,7 +196,7 @@ extension MyPageViewController {
             case .success(let data):
                 if let data = data as? MyPageResponse {
                     print(data)
-                    self.setUpdate(data: data, profileImage: Image.userDefaultImage)
+                    self.setUpdate(data: data)
                 }
             case .requestErr(let message):
                 print("requestErr", message)

--- a/Hyangyu/Hyangyu/Sources/ViewControllers/MyPage/ProfileEditViewController.swift
+++ b/Hyangyu/Hyangyu/Sources/ViewControllers/MyPage/ProfileEditViewController.swift
@@ -10,8 +10,7 @@ import UIKit
 import Then
 
 protocol ProfileEditViewControllerDelegate: class {
-//    func setUpdate(profileImage: UIImage?, userName: String?)
-    func setUpdate(data: MyPageResponse, profileImage: UIImage?)
+    func setUpdate(data: MyPageResponse)
 }
 
 struct ProfileEditViewControllerViewModel {
@@ -59,6 +58,8 @@ final class ProfileEditViewController: UIViewController {
     
     weak var delegate: ProfileEditViewControllerDelegate?
     
+    private var viewModel: ProfileEditViewControllerViewModel = ProfileEditViewControllerViewModel(profileImage: UIImage(), userName: "")
+    
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -67,11 +68,20 @@ final class ProfileEditViewController: UIViewController {
         configureUI()
         setUserNameTextField()
         setDelegation()
- 
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        configureFirstData()
     }
     
     // MARK: - Functions
-
+    
+    func configureFirstData() {
+        userProfileImageView?.image = viewModel.profileImage
+        userNameTextField?.text = viewModel.userName
+    }
+    
     func configureUI() {
         userNameTextFieldView.makeRoundedWithBorder(radius: 12, color: UIColor.systemGray2.cgColor)
         warningLabel.isHidden = true
@@ -140,7 +150,7 @@ final class ProfileEditViewController: UIViewController {
     }
     
     @IBAction func didTapConfirm(_ sender: Any) {
-//        delegate?.setUpdate(data: data)
+        //        delegate?.setUpdate(data: data)
         user.username = userNameTextField.text ?? ""
         user.profileImage = userProfileImageView.image ?? nil
         modifyUserName()
@@ -218,7 +228,7 @@ final class ProfileEditViewController: UIViewController {
         let imagePickerController = UIImagePickerController()
         imagePickerController.delegate = self
         imagePickerController.allowsEditing = true // 편집을 허용
-
+        
         let actionSheet = UIAlertController(title: "프로필 사진 선택", message: nil, preferredStyle: .actionSheet)
         actionSheet.addAction(UIAlertAction(title: "앨범에서 가져오기", style: .default, handler: { (action:UIAlertAction) in
             if(UIImagePickerController.isSourceTypeAvailable(.photoLibrary)){
@@ -253,8 +263,9 @@ final class ProfileEditViewController: UIViewController {
     }
     
     func configure(with viewModel: ProfileEditViewControllerViewModel) {
-        userProfileImageView?.image = viewModel.profileImage
-        userNameTextField?.text = viewModel.userName
+        //        userProfileImageView?.image = viewModel.profileImage
+        //        userNameTextField?.text = viewModel.userName
+        self.viewModel = viewModel
     }
     
     
@@ -305,7 +316,7 @@ extension ProfileEditViewController: UITextFieldDelegate {
 extension ProfileEditViewController {
     func modifyUserName() {
         guard let userName = User.shared.username else { return }
-
+        
         MyPageAPI.shared.modifyUserName(completion: { (response) in
             switch response {
             case .success:

--- a/Hyangyu/Hyangyu/Sources/ViewControllers/MyPage/ProfileEditViewController.xib
+++ b/Hyangyu/Hyangyu/Sources/ViewControllers/MyPage/ProfileEditViewController.xib
@@ -73,7 +73,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d24-Bb-f1j">
                     <rect key="frame" x="20" y="274" width="374" height="54"/>
                     <subviews>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="이물사딱아요" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="fB5-HF-P1I">
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="fB5-HF-P1I">
                             <rect key="frame" x="15" y="15" width="344" height="24"/>
                             <color key="textColor" name="textBlack"/>
                             <fontDescription key="fontDescription" name="AppleSDGothicNeo-Medium" family="Apple SD Gothic Neo" pointSize="15"/>


### PR DESCRIPTION
## PR 요약

### 작업한 브랜치
- feature/#36

### 작업한 내용
- 전시회 저장 서버 연결
- 저장한 전시회 취소 서버 연결
- 프로필 수정 시 이름 반영 안되던 오류 해결

## 📌 참고 사항
카테고리에서 저장할 경우 saved가 아직 반영이 되지 않았으므로 버튼 모양이 다르게 나타날 수 있습니다.
마이페이지의 내가 저장한 전시회 뷰의 경우 저장 및 삭제마다 서버에서 처음부터 데이터를 받아옵니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![savedandcancel](https://user-images.githubusercontent.com/75535902/153251944-48938da4-9643-470f-aa23-843a4faf1db7.gif)|

## 📮 관련 이슈
- Close: #36